### PR TITLE
Change assertion error to warning upon failure to register `DatasetProviderPlugin`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
         exclude: test_catalogs
@@ -12,11 +12,11 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.2
+    rev: v2.0.4
     hooks:
       - id: autopep8
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
       - id: add-trailing-comma

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# turns off codecov PR checks
+coverage:
+  status:
+    project: off
+    patch: off

--- a/examples/run_server.py
+++ b/examples/run_server.py
@@ -40,7 +40,11 @@ else:
 if CATALOG_TYPE == 'intake':
     catalog_path = root_path / 'test_catalogs' / 'test_intake_zarr_catalog.yaml'
 elif CATALOG_TYPE == 'stac':
-    catalog_path = r'https://code.usgs.gov/wma/nhgf/stac/-/raw/main/xpublish_sample_stac/catalog/catalog.json'
+    # catalog_path = r'https://code.usgs.gov/wma/nhgf/stac/-/raw/main/xpublish_sample_stac/catalog/catalog.json'
+    # catalog_path = r'https://code.usgs.gov/wma/nhgf/stac/-/raw/main/catalog2/catalog.json'
+    catalog_path = root_path / 'test_catalogs' / \
+        'sample_stac_catalog' / 'catalog.json'
+
 else:
     raise ValueError(
         f'Invalid catalog type: {CATALOG_TYPE}. Must be "intake" or "stac".',

--- a/src/catalog_to_xpublish/__init__.py
+++ b/src/catalog_to_xpublish/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 from catalog_to_xpublish.factory import (
     CatalogImplementation,
     CatalogImplementationFactory,

--- a/src/catalog_to_xpublish/server_functions.py
+++ b/src/catalog_to_xpublish/server_functions.py
@@ -157,7 +157,8 @@ def create_app(
                 plugin_name=cat_prefix,
             )
 
-            if not cat_prefix in rest_server.plugins:
+            # if cat_prefix == '', xpublish changes the name to the name of the plugin
+            if (bool(cat_prefix) and cat_prefix not in rest_server.plugins) | (not cat_prefix and provider_plugin.name not in rest_server.plugins):
                 logger.warn(
                     f'Could not add dataset provider plugin for {cat_prefix} to the server!',
                 )

--- a/src/catalog_to_xpublish/server_functions.py
+++ b/src/catalog_to_xpublish/server_functions.py
@@ -156,7 +156,7 @@ def create_app(
                 plugin=provider_plugin,
                 plugin_name=cat_prefix,
             )
-            
+
             if not cat_prefix in rest_server.plugins:
                 logger.warn(
                     f'Could not add dataset provider plugin for {cat_prefix} to the server!',

--- a/src/catalog_to_xpublish/server_functions.py
+++ b/src/catalog_to_xpublish/server_functions.py
@@ -156,7 +156,12 @@ def create_app(
                 plugin=provider_plugin,
                 plugin_name=cat_prefix,
             )
-            assert cat_prefix in rest_server.plugins
+            
+            if not cat_prefix in rest_server.plugins:
+                logger.warn(
+                    f'Could not add dataset provider plugin for {cat_prefix} to the server!',
+                )
+                continue
 
             # add all non-dataset provider plugins
             for plugin in app_inputs.xpublish_plugins:


### PR DESCRIPTION
**Background:** Upon iterating all "catalog endpoints" (aka levels in a catalogs hierarchy), if the "endpoint" contains links to datasets (NetCDF or Zarr formats) a `catalog_to_xpublish.provider_plugin.DatasetProviderPlugin` is instantiated and registered to our FastAPI router. By following the [`xpublish` Dataset provider plugin pattern](https://xpublish.readthedocs.io/en/0.3.3/getting-started/tutorial/dataset-provider-plugin.html), this object uses a subclass of the `base.io_base.CatalogToXarray` abstract base class (i.e., the Intake or STAC subclass) to enable `xpublish` to read our dataset file links into in memory `xarray.Dataset`s objects, which can then be served via other `xpublish` based endpoints. @ptomasula @sjordan29 @aufdenkampe 

**Issue:** Before this PR, the build will fail if there is an issue with instantiating our `catalog_to_xpublish.provider_plugin.DatasetProviderPlugin` at any "endpoint" within the catalog. This is bad behavior, as a STAC/Intake catalog can be huge and contain many layers/endpoints, therefore preventing a build because of a single typo is undesirable. We also want to avoid any other handle any other exceptions during the loop over catalog endpoints in `server_functions.create_app()`, which would cause the same issue.

**Fix:** 
* Instead of throwing an AssertionError, we log a warning specifying at which catalog endpoint the failure occurred and skip any following steps for that endpoint.
*  I checked everywhere errors could occur, and in all cases, they seemed impossible to trigger within the loop. Higher up, such as when `CatalogEndpoint` objects are initialized, there can be issues but those are handled with their own warning.
* Since the one place of potential silent failure is registering the `DatasetProviderPlugin`, that is where we formally check if everything worked out OK.
* There is no risk of overlapping plugin names, as each "catalog endpoint" is given only one additional plugin, and all `xpublish` native plugins have names that don't begin with a '/'.

