### PR TITLE
Adding support for `fastapi.FastAPI` kwargs

### DIFF
--- a/src/catalog_to_xpublish/__init__.py
+++ b/src/catalog_to_xpublish/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 from catalog_to_xpublish.factory import (
     CatalogImplementation,
     CatalogImplementationFactory,

--- a/src/catalog_to_xpublish/server_functions.py
+++ b/src/catalog_to_xpublish/server_functions.py
@@ -95,6 +95,7 @@ def create_app(
     catalog_type: str,
     app_name: Optional[str] = None,
     xpublish_plugins: Optional[List[xpublish.Plugin]] = None,
+    fastapi_kwargs: Optional[dict] = None,
     config_logging_dict: Optional[LoggingConfigDict] = None,
 ) -> FastAPI:
     """Main function to create the server app.
@@ -104,6 +105,8 @@ def create_app(
         catalog_type: The type of catalog to parse.
         app_name: The name of the app.
         xpublish_plugins: A list of external xpublish plugin classes to use.
+        fastapi_kwargs: A dictionary of kwargs passed into fastapi.FastAPI().
+        config_logging_dict: A dictionary of logging configuration parameters.
     Returns:
         A FastAPI app object.
     """
@@ -130,7 +133,15 @@ def create_app(
     catalog_endpoints: List[CatalogEndpoint] = catalog_searcher.parse_catalog()
 
     # 2. Start a Xpublish server
-    app = FastAPI(title=app_inputs.name)
+    if not isinstance(fastapi_kwargs, dict):
+        fastapi_kwargs = {}
+    if 'title' in fastapi_kwargs:
+        logger.warn(
+            f'Overwriting title={fastapi_kwargs["title"]} with title={app_inputs.name}! '
+            'Use param:app_name to set the title of the app, not param:faskapi_kwargs.',
+        )
+        del fastapi_kwargs['title']
+    app = FastAPI(title=app_inputs.name, **fastapi_kwargs)
 
     # 2. Iterate through the endpoints and add them to the server
     for cat_end in catalog_endpoints:

--- a/test_catalogs/intake_zarr_catalog_osn.yaml
+++ b/test_catalogs/intake_zarr_catalog_osn.yaml
@@ -1,17 +1,5 @@
 sources:
 
-  conus404-hourly-osn:
-    driver: zarr
-    description: "CONUS404 - OSN pod storage, 70 TB, 40 years of hourly data, CONUS extent with 4 km gridded spatial resolution, 157 variables"
-    args:
-      urlpath: 's3://rsignellbucket2/hytest/conus404/conus404_hourly_202302.zarr'
-      consolidated: true
-      storage_options:
-        anon: true
-        requester_pays: false
-        client_kwargs:
-          endpoint_url: https://renc.osn.xsede.org
-
   nwis-streamflow-usgs-gages-osn:
     driver: zarr
     description: "subset of NWIS streamflow - OSN pod storage, 275 MB, 40 years of daily data, CONUS extent point data, 1 real variable (streamflow)"

--- a/test_catalogs/sample_stac_catalog/conus-404/collection.json
+++ b/test_catalogs/sample_stac_catalog/conus-404/collection.json
@@ -26,7 +26,7 @@
     ],
     "assets": {
         "zarr-osn": {
-            "href": "s3://rsignellbucket2/hytest/conus404/conus404_hourly_202302.zarr",
+            "href": "s3://rsignellbucket2/hytest/nwm/nwis_chanobs.zarr",
             "type": "application/vnd+zarr",
             "description": "OSN access to collection zarr group",
             "xarray:open_kwargs": {

--- a/tests/test_5_run_intake_server.py
+++ b/tests/test_5_run_intake_server.py
@@ -32,12 +32,14 @@ def app(catalog_path: Path) -> fastapi.FastAPI:
         catalog_path=catalog_path,
         catalog_type='intake',
         app_name='intake_test_app',
+        fastapi_kwargs={'description': 'testing fastapi_kwargs'},
         config_logging_dict={'log_file': 'intake_test_app.log'},
     )
 
     # check that things are in place
     assert isinstance(app, fastapi.FastAPI)
     assert app.title == 'intake_test_app'
+    assert app.description == 'testing fastapi_kwargs'
     assert Path(Path.cwd() / 'intake_test_app.log').exists()
     return app
 

--- a/tests/test_5_run_intake_server.py
+++ b/tests/test_5_run_intake_server.py
@@ -108,7 +108,6 @@ def test_datasets_endpoints(
     response = client.get('/osn_catalog/datasets')
     assert response.status_code == 200
     assert response.json() == [
-        'conus404-hourly-osn',
         'nwis-streamflow-usgs-gages-osn',
         'red-river-subset-osn',
         'alaska-et-2020-subset-osn',


### PR DESCRIPTION
**Problem:** There are use cases where one might want to customize the `fastapi.FastAPI` app via keyword arguments (docs [here](https://fastapi.tiangolo.com/reference/fastapi/)). Previously, there as no option to do so.

**Solution:** A new, optional, `fastapi_kwargs` argument for `catalog_to_xpublish.create_app()`! These arguments are passed directly into `fastapi.FastAPI` except for "title", which is overridden by `param:app_name` (a warning if given if these conflict). I added test coverage for this new feature as well.