### PR TITLE
STAC search use assets directly

### DIFF
--- a/src/catalog_to_xpublish/searchers/stac_search.py
+++ b/src/catalog_to_xpublish/searchers/stac_search.py
@@ -107,7 +107,7 @@ class STACCatalogSearch(CatalogSearcher):
         dataset_info_dicts: Dict[str, Dict[str, Any]],
     ) -> None:
         """Adds all assets to the list + dict of datasets."""
-        for child_name, child in pystac_obj.get_assets().items():
+        for child_name, child in pystac_obj.assets.items():
             # make sure the item type is supported
             url_path = child.get_absolute_href()
             if url_path.endswith('/'):


### PR DESCRIPTION
# Relate issue(s)
#15

# Background 
After running performance profiling, I found that a large amount of time was spent in the python's deepcopy. The get_assets call returns a copy of the asset list, which we are iterating over. By using the assets directly we can avoid the copy step and save a bunch of overhead.