### PR TITLE
Fix catalogs not returning correct/all subcatalogs

### DIFF
--- a/src/catalog_to_xpublish/__init__.py
+++ b/src/catalog_to_xpublish/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.3'
+__version__ = "0.1.6"
 from catalog_to_xpublish.factory import (
     CatalogImplementation,
     CatalogImplementationFactory,

--- a/src/catalog_to_xpublish/server_functions.py
+++ b/src/catalog_to_xpublish/server_functions.py
@@ -216,7 +216,8 @@ def create_app(
             router = app_inputs.catalog_implementation.catalog_router(
                 catalog_endpoint_obj=cat_end,
             )
-            app.include_router(router=router.router)
+            # add prefix?
+            app.include_router(router=router.router, prefix=cat_prefix)
     logger.info(
         f'Returning successfully created server application!',
     )


### PR DESCRIPTION
When building against a catalogs with multiple subcatalogs that do not have datasets in the sub catalog's root, the /Catalogs endpoint for the root application was returning the first subcatalogs information. This made it difficult to navigate and identify datasets in the root catalog.   